### PR TITLE
Add Hanzilla Jobs remote Canada board

### DIFF
--- a/Remote-Job-Boards
+++ b/Remote-Job-Boards
@@ -41,5 +41,5 @@
 39. web3.career
 40. useweb3.xyz
 41. ethlance.com
-42. jobs.hanzilla.co/locations/remote/ - Canada remote student, internship, co-op, new-grad, and junior roles
+42. jobs.hanzilla.co/locations/remote/
 

--- a/Remote-Job-Boards
+++ b/Remote-Job-Boards
@@ -41,4 +41,5 @@
 39. web3.career
 40. useweb3.xyz
 41. ethlance.com
+42. jobs.hanzilla.co/locations/remote/ - Canada remote student, internship, co-op, new-grad, and junior roles
 


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs' remote Canada landing page to the remote job boards list.

## Why this is different
- Hanzilla Jobs is Canada-specific and aimed at students/recent grads looking for internships, co-ops, new-grad, junior, and entry-level roles.
- The linked page filters to remote Canada roles, which complements the existing general remote boards.
- The board is free to browse and does not require login.

## Link
https://jobs.hanzilla.co/locations/remote/
